### PR TITLE
api_endpoint: __get_permissions_class__: only return name of class

### DIFF
--- a/rest_framework_docs/api_endpoint.py
+++ b/rest_framework_docs/api_endpoint.py
@@ -89,7 +89,8 @@ class ApiEndpoint(object):
 
     def __get_permissions_class__(self):
         for perm_class in self.pattern.callback.cls.permission_classes:
-            return perm_class.__name__
+            if inspect.isclass(perm_class):
+                return perm_class.__name__
 
     def __get_serializer__(self):
         try:


### PR DESCRIPTION
Fixes https://github.com/manosim/django-rest-framework-docs/issues/181